### PR TITLE
Hinzufügen der Funktion Remote HTTP Adressen als download_path und kleine Code Optimierung

### DIFF
--- a/ffrouter_parsen.function.php
+++ b/ffrouter_parsen.function.php
@@ -44,7 +44,7 @@ if (filter_var($community[$community_id]["download_path"], FILTER_VALIDATE_URL) 
                     $variante[$entwicklung[$i]][$installation[$j]] = 1;
                     $files[$entwicklung[$i]][$installation[$j]] = array_slice(scandir($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/"), 2);
                     $file_count = count($files[$entwicklung[$i]][$installation[$j]]);
-                    for( $x=0; $x<$file_count); $x++ ) {
+                    for( $x=0; $x<$file_count; $x++ ) {
                         if(is_dir($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/".$files[$entwicklung[$i]][$installation[$j]][$x])) {
                             array_splice($files[$entwicklung[$i]][$installation[$j]], $x, 1);
                             $x--;
@@ -81,7 +81,7 @@ if (filter_var($community[$community_id]["download_path"], FILTER_VALIDATE_URL) 
         for( $j=0; $j<$installation_count; $j++ ) {
             if($variante[$entwicklung[$i]][$installation[$j]] == 1) {
                 $file_count = count($files[$entwicklung[$i]][$installation[$j]]);
-                for( $x=0; $x<$file_count); $x++) {
+                for( $x=0; $x<$file_count; $x++) {
                     for( $y=0; $y<$anzahl_hersteller; $y++) {
                         if($pos = stripos($files[$entwicklung[$i]][$installation[$j]][$x], $hersteller[$y]['filename'], $pos_hersteller[$entwicklung[$i]][$installation[$j]]-1) !== false) {
                             $router_tmp[$x]['hersteller'] = $hersteller[$y]['name'];

--- a/ffrouter_parsen.function.php
+++ b/ffrouter_parsen.function.php
@@ -4,106 +4,221 @@
 * @copyright 2016 Caspar Armster, Freifunk Hennef/Freie Netzwerker e.V. (www.freifunk-hennef.de / www.freie-netzwerker.de)
 * @license   Licensed under GPLv3
 */
-if(!is_dir($firmware_download_path)) {
-    throw new Exception("Firmwareverzeichnis existiert nicht!");
-}
-$err = 0;
-for( $i=0; $i<count($entwicklung); $i++ ) {
-    for( $j=0; $j<count($installation); $j++ ) {
-        if(is_dir($firmware_download_path.$entwicklung[$i]."/")) {
-            if(is_dir($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/")) {
-                $variante[$entwicklung[$i]][$installation[$j]] = 1;
-                $files[$entwicklung[$i]][$installation[$j]] = array_slice(scandir($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/"), 2);
-                for( $x=0; $x<count($files[$entwicklung[$i]][$installation[$j]]); $x++ ) {
-                    if(is_dir($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/".$files[$entwicklung[$i]][$installation[$j]][$x])) {
-                        array_splice($files[$entwicklung[$i]][$installation[$j]], $x, 1);
-                        $x--;
-                    } else {
-                        $pos = stripos($files[$entwicklung[$i]][$installation[$j]][$x], 'manifest');
-                        if($pos !== false) {
+if (filter_var($community[$community_id]["download_path"], FILTER_VALIDATE_URL) === FALSE) {
+    if(!is_dir($firmware_download_path)) {
+        throw new Exception("Firmwareverzeichnis existiert nicht!");
+    }
+    $err = 0;
+    for( $i=0; $i<count($entwicklung); $i++ ) {
+        for( $j=0; $j<count($installation); $j++ ) {
+            if(is_dir($firmware_download_path.$entwicklung[$i]."/")) {
+                if(is_dir($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/")) {
+                    $variante[$entwicklung[$i]][$installation[$j]] = 1;
+                    $files[$entwicklung[$i]][$installation[$j]] = array_slice(scandir($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/"), 2);
+                    for( $x=0; $x<count($files[$entwicklung[$i]][$installation[$j]]); $x++ ) {
+                        if(is_dir($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/".$files[$entwicklung[$i]][$installation[$j]][$x])) {
                             array_splice($files[$entwicklung[$i]][$installation[$j]], $x, 1);
                             $x--;
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-for( $i=0; $i<count($entwicklung); $i++ ) {
-    for( $j=0; $j<count($installation); $j++ ) {
-        if($variante[$entwicklung[$i]][$installation[$j]] == 1) {
-            $x = 0;
-            while($files[$entwicklung[$i]][$installation[$j]][$x] !== false) {
-                $pos_hersteller[$entwicklung[$i]][$installation[$j]] = stripos($files[$entwicklung[$i]][$installation[$j]][$x], "tp-link");
-                if ($pos_hersteller[$entwicklung[$i]][$installation[$j]] !== false) {
-                    break;
-                }
-                $x++;
-            }
-        } else {
-            $pos_hersteller[$entwicklung[$i]][$installation[$j]] = 0;
-        }
-    }
-}
-$router = array();
-for( $i=0; $i<count($entwicklung); $i++ ) {
-    for( $j=0; $j<count($installation); $j++ ) {
-        if($variante[$entwicklung[$i]][$installation[$j]] == 1) {
-            for( $x=0; $x<count($files[$entwicklung[$i]][$installation[$j]]); $x++) {
-                for( $y=0; $y<$anzahl_hersteller; $y++) {
-                    if($pos = stripos($files[$entwicklung[$i]][$installation[$j]][$x], $hersteller[$y]['filename'], $pos_hersteller[$entwicklung[$i]][$installation[$j]]-1) !== false) {
-                        $router_tmp[$x]['hersteller'] = $hersteller[$y]['name'];
-                        switch($router_tmp[$x]['hersteller']) {
-                            case "D-Link":
-                                $router_tmp[$x]['version'] = substr($files[$entwicklung[$i]][$installation[$j]][$x], strripos($files[$entwicklung[$i]][$installation[$j]][$x], "rev"), -4-$offset_sysupgrade[$j]);
-                                break;
-                            case "GL-Inet (alt)":
-                                $router_tmp[$x]['version'] = substr($files[$entwicklung[$i]][$installation[$j]][$x], strripos($files[$entwicklung[$i]][$installation[$j]][$x], "v"), -4-$offset_sysupgrade[$j]);
-                                break;
-                            case "TP-Link":
-                                $router_tmp[$x]['version'] = substr($files[$entwicklung[$i]][$installation[$j]][$x], strripos($files[$entwicklung[$i]][$installation[$j]][$x], "v"), -4-$offset_sysupgrade[$j]);
-                                break;
-                            default:
-                                $router_tmp[$x]['version'] = "Alle";
-                        }
-                        $router_tmp[$x]['modell'] = strtoupper(substr($files[$entwicklung[$i]][$installation[$j]][$x], $pos_hersteller[$entwicklung[$i]][$installation[$j]]+$hersteller[$y]['offset_modell'], strripos($files[$entwicklung[$i]][$installation[$j]][$x], ".", -4)-strlen($files[$entwicklung[$i]][$installation[$j]][$x])-strlen($router_tmp[$x]['version'])+$hersteller[$y]['offset_version']-$offset_sysupgrade[$j]));
-                    }
-                }
-                if(isset($router_tmp[$x]['hersteller']) != true) {
-                    $error_text[$err]="Unbekannten Hersteller im Dateinamen gefunden, bitte Script updaten! (".$files[$entwicklung[$i]][$installation[$j]][$x].")";
-                    $err++;
-                } else {
-                    $router_neu = 1;
-                    for( $z=0; $z<count($router); $z++) {
-                        if(isset($router[$z])) {
-                            if((strcasecmp($router[$z]->hersteller, $router_tmp[$x]['hersteller']) == 0) && (strcasecmp($router[$z]->modell, $router_tmp[$x]['modell']) == 0) && (strcasecmp($router[$z]->version, $router_tmp[$x]['version']) == 0)) {
-                                $entinst = $entwicklung[$i].$installation[$j];
-                                $entinstlink = $entwicklung[$i].$installation[$j]."link";
-                                $router[$z]->$entinst = 1;
-                                $router[$z]->$entinstlink = $firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/".$files[$entwicklung[$i]][$installation[$j]][$x];
-                                $router_neu = 0;
-                                break;
+                        } else {
+                            $pos = stripos($files[$entwicklung[$i]][$installation[$j]][$x], 'manifest');
+                            if($pos !== false) {
+                                array_splice($files[$entwicklung[$i]][$installation[$j]], $x, 1);
+                                $x--;
                             }
                         }
                     }
-                    if($router_neu == 1) {
-                        $z = count($router);
-                        $router[$z] = new ffrouter();
-                        $router[$z]->hersteller = $router_tmp[$x]['hersteller'];
-                        $router[$z]->version = $router_tmp[$x]['version'];
-                        $router[$z]->modell = $router_tmp[$x]['modell'];
-                        $entinst = $entwicklung[$i].$installation[$j];
-                        $entinstlink = $entwicklung[$i].$installation[$j]."link";
-                        $router[$z]->$entinst = 1;
-                        $router[$z]->$entinstlink = $firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/".$files[$entwicklung[$i]][$installation[$j]][$x];
+                }
+            }
+        }
+    }
+    for( $i=0; $i<count($entwicklung); $i++ ) {
+        for( $j=0; $j<count($installation); $j++ ) {
+            if($variante[$entwicklung[$i]][$installation[$j]] == 1) {
+                $x = 0;
+                while($files[$entwicklung[$i]][$installation[$j]][$x] !== false) {
+                    $pos_hersteller[$entwicklung[$i]][$installation[$j]] = stripos($files[$entwicklung[$i]][$installation[$j]][$x], "tp-link");
+                    if ($pos_hersteller[$entwicklung[$i]][$installation[$j]] !== false) {
+                        break;
+                    }
+                    $x++;
+                }
+            } else {
+                $pos_hersteller[$entwicklung[$i]][$installation[$j]] = 0;
+            }
+        }
+    }
+    $router = array();
+    for( $i=0; $i<count($entwicklung); $i++ ) {
+        for( $j=0; $j<count($installation); $j++ ) {
+            if($variante[$entwicklung[$i]][$installation[$j]] == 1) {
+                for( $x=0; $x<count($files[$entwicklung[$i]][$installation[$j]]); $x++) {
+                    for( $y=0; $y<$anzahl_hersteller; $y++) {
+                        if($pos = stripos($files[$entwicklung[$i]][$installation[$j]][$x], $hersteller[$y]['filename'], $pos_hersteller[$entwicklung[$i]][$installation[$j]]-1) !== false) {
+                            $router_tmp[$x]['hersteller'] = $hersteller[$y]['name'];
+                            switch($router_tmp[$x]['hersteller']) {
+                                case "D-Link":
+                                    $router_tmp[$x]['version'] = substr($files[$entwicklung[$i]][$installation[$j]][$x], strripos($files[$entwicklung[$i]][$installation[$j]][$x], "rev"), -4-$offset_sysupgrade[$j]);
+                                    break;
+                                case "GL-Inet (alt)":
+                                    $router_tmp[$x]['version'] = substr($files[$entwicklung[$i]][$installation[$j]][$x], strripos($files[$entwicklung[$i]][$installation[$j]][$x], "v"), -4-$offset_sysupgrade[$j]);
+                                    break;
+                                case "TP-Link":
+                                    $router_tmp[$x]['version'] = substr($files[$entwicklung[$i]][$installation[$j]][$x], strripos($files[$entwicklung[$i]][$installation[$j]][$x], "v"), -4-$offset_sysupgrade[$j]);
+                                    break;
+                                default:
+                                    $router_tmp[$x]['version'] = "Alle";
+                            }
+                            $router_tmp[$x]['modell'] = strtoupper(substr($files[$entwicklung[$i]][$installation[$j]][$x], $pos_hersteller[$entwicklung[$i]][$installation[$j]]+$hersteller[$y]['offset_modell'], strripos($files[$entwicklung[$i]][$installation[$j]][$x], ".", -4)-strlen($files[$entwicklung[$i]][$installation[$j]][$x])-strlen($router_tmp[$x]['version'])+$hersteller[$y]['offset_version']-$offset_sysupgrade[$j]));
+                        }
+                    }
+                    if(isset($router_tmp[$x]['hersteller']) != true) {
+                        $error_text[$err]="Unbekannten Hersteller im Dateinamen gefunden, bitte Script updaten! (".$files[$entwicklung[$i]][$installation[$j]][$x].")";
+                        $err++;
+                    } else {
+                        $router_neu = 1;
+                        for( $z=0; $z<count($router); $z++) {
+                            if(isset($router[$z])) {
+                                if((strcasecmp($router[$z]->hersteller, $router_tmp[$x]['hersteller']) == 0) && (strcasecmp($router[$z]->modell, $router_tmp[$x]['modell']) == 0) && (strcasecmp($router[$z]->version, $router_tmp[$x]['version']) == 0)) {
+                                    $entinst = $entwicklung[$i].$installation[$j];
+                                    $entinstlink = $entwicklung[$i].$installation[$j]."link";
+                                    $router[$z]->$entinst = 1;
+                                    $router[$z]->$entinstlink = $firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/".$files[$entwicklung[$i]][$installation[$j]][$x];
+                                    $router_neu = 0;
+                                    break;
+                                }
+                            }
+                        }
+                        if($router_neu == 1) {
+                            $z = count($router);
+                            $router[$z] = new ffrouter();
+                            $router[$z]->hersteller = $router_tmp[$x]['hersteller'];
+                            $router[$z]->version = $router_tmp[$x]['version'];
+                            $router[$z]->modell = $router_tmp[$x]['modell'];
+                            $entinst = $entwicklung[$i].$installation[$j];
+                            $entinstlink = $entwicklung[$i].$installation[$j]."link";
+                            $router[$z]->$entinst = 1;
+                            $router[$z]->$entinstlink = $firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/".$files[$entwicklung[$i]][$installation[$j]][$x];
+                        }
+                    }
+                }
+            }
+            $router_tmp = array();
+        }
+    }
+}else{
+    //Check if URL is reachable
+    if (!@fopen($firmware_download_path,"r")) {
+        throw new Exception("Firmwareverzeichnis offline oder nicht existent!");
+    }
+    
+    //Check if URL has index file (refer to https://forums.phpfreaks.com/topic/112764-using-scandir-on-other-websites/?p=579166  <- scandir has problem with index files)
+    if ((@fopen($firmware_download_path."/index.htm","r"))||(@fopen($firmware_download_path."/index.html","r"))||(@fopen($firmware_download_path."/index.php","r"))) {
+        throw new Exception("Firmwareverzeichnis darf keine index files besitzen!");
+    }
+    
+    $err = 0;
+    for( $i=0; $i<count($entwicklung); $i++ ) {
+        for( $j=0; $j<count($installation); $j++ ) {
+            if(is_dir($firmware_download_path.$entwicklung[$i]."/")) {
+                if(is_dir($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/")) {
+                    //Check if URL has index file (refer to https://forums.phpfreaks.com/topic/112764-using-scandir-on-other-websites/?p=579166  <- scandir has problem with index files)
+                    if ((@fopen($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/index.htm","r"))||(@fopen($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/index.html","r"))||(@fopen($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/index.php","r"))) {
+                        throw new Exception("Firmwareverzeichnis darf keine index files besitzen!");
+                    }
+                    $variante[$entwicklung[$i]][$installation[$j]] = 1;
+                    $files[$entwicklung[$i]][$installation[$j]] = array_slice(scandir($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/"), 2);
+                    for( $x=0; $x<count($files[$entwicklung[$i]][$installation[$j]]); $x++ ) {
+                        if(is_dir($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/".$files[$entwicklung[$i]][$installation[$j]][$x])) {
+                            array_splice($files[$entwicklung[$i]][$installation[$j]], $x, 1);
+                            $x--;
+                        } else {
+                            $pos = stripos($files[$entwicklung[$i]][$installation[$j]][$x], 'manifest');
+                            if($pos !== false) {
+                                array_splice($files[$entwicklung[$i]][$installation[$j]], $x, 1);
+                                $x--;
+                            }
+                        }
                     }
                 }
             }
         }
-        $router_tmp = array();
+    }
+    for( $i=0; $i<count($entwicklung); $i++ ) {
+        for( $j=0; $j<count($installation); $j++ ) {
+            if($variante[$entwicklung[$i]][$installation[$j]] == 1) {
+                $x = 0;
+                while($files[$entwicklung[$i]][$installation[$j]][$x] !== false) {
+                    $pos_hersteller[$entwicklung[$i]][$installation[$j]] = stripos($files[$entwicklung[$i]][$installation[$j]][$x], "tp-link");
+                    if ($pos_hersteller[$entwicklung[$i]][$installation[$j]] !== false) {
+                        break;
+                    }
+                    $x++;
+                }
+            } else {
+                $pos_hersteller[$entwicklung[$i]][$installation[$j]] = 0;
+            }
+        }
+    }
+    $router = array();
+    for( $i=0; $i<count($entwicklung); $i++ ) {
+        for( $j=0; $j<count($installation); $j++ ) {
+            if($variante[$entwicklung[$i]][$installation[$j]] == 1) {
+                for( $x=0; $x<count($files[$entwicklung[$i]][$installation[$j]]); $x++) {
+                    for( $y=0; $y<$anzahl_hersteller; $y++) {
+                        if($pos = stripos($files[$entwicklung[$i]][$installation[$j]][$x], $hersteller[$y]['filename'], $pos_hersteller[$entwicklung[$i]][$installation[$j]]-1) !== false) {
+                            $router_tmp[$x]['hersteller'] = $hersteller[$y]['name'];
+                            switch($router_tmp[$x]['hersteller']) {
+                                case "D-Link":
+                                    $router_tmp[$x]['version'] = substr($files[$entwicklung[$i]][$installation[$j]][$x], strripos($files[$entwicklung[$i]][$installation[$j]][$x], "rev"), -4-$offset_sysupgrade[$j]);
+                                    break;
+                                case "GL-Inet (alt)":
+                                    $router_tmp[$x]['version'] = substr($files[$entwicklung[$i]][$installation[$j]][$x], strripos($files[$entwicklung[$i]][$installation[$j]][$x], "v"), -4-$offset_sysupgrade[$j]);
+                                    break;
+                                case "TP-Link":
+                                    $router_tmp[$x]['version'] = substr($files[$entwicklung[$i]][$installation[$j]][$x], strripos($files[$entwicklung[$i]][$installation[$j]][$x], "v"), -4-$offset_sysupgrade[$j]);
+                                    break;
+                                default:
+                                    $router_tmp[$x]['version'] = "Alle";
+                            }
+                            $router_tmp[$x]['modell'] = strtoupper(substr($files[$entwicklung[$i]][$installation[$j]][$x], $pos_hersteller[$entwicklung[$i]][$installation[$j]]+$hersteller[$y]['offset_modell'], strripos($files[$entwicklung[$i]][$installation[$j]][$x], ".", -4)-strlen($files[$entwicklung[$i]][$installation[$j]][$x])-strlen($router_tmp[$x]['version'])+$hersteller[$y]['offset_version']-$offset_sysupgrade[$j]));
+                        }
+                    }
+                    if(isset($router_tmp[$x]['hersteller']) != true) {
+                        $error_text[$err]="Unbekannten Hersteller im Dateinamen gefunden, bitte Script updaten! (".$files[$entwicklung[$i]][$installation[$j]][$x].")";
+                        $err++;
+                    } else {
+                        $router_neu = 1;
+                        for( $z=0; $z<count($router); $z++) {
+                            if(isset($router[$z])) {
+                                if((strcasecmp($router[$z]->hersteller, $router_tmp[$x]['hersteller']) == 0) && (strcasecmp($router[$z]->modell, $router_tmp[$x]['modell']) == 0) && (strcasecmp($router[$z]->version, $router_tmp[$x]['version']) == 0)) {
+                                    $entinst = $entwicklung[$i].$installation[$j];
+                                    $entinstlink = $entwicklung[$i].$installation[$j]."link";
+                                    $router[$z]->$entinst = 1;
+                                    $router[$z]->$entinstlink = $firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/".$files[$entwicklung[$i]][$installation[$j]][$x];
+                                    $router_neu = 0;
+                                    break;
+                                }
+                            }
+                        }
+                        if($router_neu == 1) {
+                            $z = count($router);
+                            $router[$z] = new ffrouter();
+                            $router[$z]->hersteller = $router_tmp[$x]['hersteller'];
+                            $router[$z]->version = $router_tmp[$x]['version'];
+                            $router[$z]->modell = $router_tmp[$x]['modell'];
+                            $entinst = $entwicklung[$i].$installation[$j];
+                            $entinstlink = $entwicklung[$i].$installation[$j]."link";
+                            $router[$z]->$entinst = 1;
+                            $router[$z]->$entinstlink = $firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/".$files[$entwicklung[$i]][$installation[$j]][$x];
+                        }
+                    }
+                }
+            }
+            $router_tmp = array();
+        }
     }
 }
+
 for( $i=0; $i<count($router); $i++ ) { // Routerbilder einbauen
     if(is_dir(strtolower("router_images/".$router[$i]->hersteller))) {
         if(is_file(strtolower("router_images/".$router[$i]->hersteller."/".$router[$i]->modell."-".$router[$i]->version.".jpg"))) {

--- a/ffrouter_parsen.function.php
+++ b/ffrouter_parsen.function.php
@@ -29,18 +29,22 @@ function remoteFileExists($url) {
 
     return $ret;
 }
+
 if (filter_var($community[$community_id]["download_path"], FILTER_VALIDATE_URL) === FALSE) {
     if(!is_dir($firmware_download_path)) {
         throw new Exception("Firmwareverzeichnis existiert nicht!");
     }
     $err = 0;
-    for( $i=0; $i<count($entwicklung); $i++ ) {
-        for( $j=0; $j<count($installation); $j++ ) {
+    $entwicklung_count = count($entwicklung);    
+    $installation_count = count($installation);
+    for( $i=0; $i<$entwicklung_count; $i++ ) {
+        for( $j=0; $j<$installation_count; $j++ ) {
             if(is_dir($firmware_download_path.$entwicklung[$i]."/")) {
                 if(is_dir($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/")) {
                     $variante[$entwicklung[$i]][$installation[$j]] = 1;
                     $files[$entwicklung[$i]][$installation[$j]] = array_slice(scandir($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/"), 2);
-                    for( $x=0; $x<count($files[$entwicklung[$i]][$installation[$j]]); $x++ ) {
+                    $file_count = count($files[$entwicklung[$i]][$installation[$j]]);
+                    for( $x=0; $x<$file_count); $x++ ) {
                         if(is_dir($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/".$files[$entwicklung[$i]][$installation[$j]][$x])) {
                             array_splice($files[$entwicklung[$i]][$installation[$j]], $x, 1);
                             $x--;
@@ -56,8 +60,8 @@ if (filter_var($community[$community_id]["download_path"], FILTER_VALIDATE_URL) 
             }
         }
     }
-    for( $i=0; $i<count($entwicklung); $i++ ) {
-        for( $j=0; $j<count($installation); $j++ ) {
+    for( $i=0; $i<$entwicklung_count; $i++ ) {
+        for( $j=0; $j<$installation_count; $j++ ) {
             if($variante[$entwicklung[$i]][$installation[$j]] == 1) {
                 $x = 0;
                 while($files[$entwicklung[$i]][$installation[$j]][$x] !== false) {
@@ -73,10 +77,11 @@ if (filter_var($community[$community_id]["download_path"], FILTER_VALIDATE_URL) 
         }
     }
     $router = array();
-    for( $i=0; $i<count($entwicklung); $i++ ) {
-        for( $j=0; $j<count($installation); $j++ ) {
+    for( $i=0; $i<$entwicklung_count; $i++ ) {
+        for( $j=0; $j<$installation_count; $j++ ) {
             if($variante[$entwicklung[$i]][$installation[$j]] == 1) {
-                for( $x=0; $x<count($files[$entwicklung[$i]][$installation[$j]]); $x++) {
+                $file_count = count($files[$entwicklung[$i]][$installation[$j]]);
+                for( $x=0; $x<$file_count); $x++) {
                     for( $y=0; $y<$anzahl_hersteller; $y++) {
                         if($pos = stripos($files[$entwicklung[$i]][$installation[$j]][$x], $hersteller[$y]['filename'], $pos_hersteller[$entwicklung[$i]][$installation[$j]]-1) !== false) {
                             $router_tmp[$x]['hersteller'] = $hersteller[$y]['name'];
@@ -101,7 +106,8 @@ if (filter_var($community[$community_id]["download_path"], FILTER_VALIDATE_URL) 
                         $err++;
                     } else {
                         $router_neu = 1;
-                        for( $z=0; $z<count($router); $z++) {
+                        $router_count = count($router);
+                        for( $z=0; $z<$router_count; $z++) {
                             if(isset($router[$z])) {
                                 if((strcasecmp($router[$z]->hersteller, $router_tmp[$x]['hersteller']) == 0) && (strcasecmp($router[$z]->modell, $router_tmp[$x]['modell']) == 0) && (strcasecmp($router[$z]->version, $router_tmp[$x]['version']) == 0)) {
                                     $entinst = $entwicklung[$i].$installation[$j];
@@ -136,44 +142,33 @@ if (filter_var($community[$community_id]["download_path"], FILTER_VALIDATE_URL) 
         throw new Exception("Firmwareverzeichnis offline oder nicht existent!");
     }
     
-    //Check if URL has index file (refer to https://forums.phpfreaks.com/topic/112764-using-scandir-on-other-websites/?p=579166  <- scandir has problem with index files)
-    if ((@remoteFileExists($firmware_download_path."/index.htm"))||(@remoteFileExists($firmware_download_path."/index.html"))||(@remoteFileExists($firmware_download_path."/index.php"))) {
-        throw new Exception("Firmwareverzeichnis darf keine index files besitzen!");
-    }
-
     $err = 0;
-    for( $i=0; $i<count($entwicklung); $i++ ) {
-        for( $j=0; $j<count($installation); $j++ ) {
-            if(remoteFileExists($firmware_download_path.$entwicklung[$i]."/")) {
-                if(@remoteFileExists($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/")) {
-                    //Check if URL has index file (refer to https://forums.phpfreaks.com/topic/112764-using-scandir-on-other-websites/?p=579166  <- scandir has problem with index files)
-                    if ((@remoteFileExists($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/index.htm"))||(@remoteFileExists($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/index.html"))||(@remoteFileExists($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/index.php"))) {
-                        throw new Exception("Firmwareverzeichnis darf keine index files besitzen!");
-                    }
-                    $variante[$entwicklung[$i]][$installation[$j]] = 1;
-                    preg_match_all('/href=[\'"]?([^\'" >]+)/', file_get_contents($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/"), $files_in_HTTP);
-                    foreach($files_in_HTTP["0"] as $key=>$value){
-                        $files_in_HTTP["0"][$key]=substr($value, 6);
-                    }
-                    $files[$entwicklung[$i]][$installation[$j]] = array_slice($files_in_HTTP["0"], 1);
-                    for( $x=0; $x<count($files[$entwicklung[$i]][$installation[$j]]); $x++ ) {
-                        if(@remoteFileExists($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/".$files[$entwicklung[$i]][$installation[$j]][$x])) {
-                            array_splice($files[$entwicklung[$i]][$installation[$j]], $x, 1);
-                            // $x--;
-                        } else {
-                            $pos = stripos($files[$entwicklung[$i]][$installation[$j]][$x], 'manifest');
-                            if($pos !== false) {
-                                array_splice($files[$entwicklung[$i]][$installation[$j]], $x, 1);
-                                // $x--;
-                            }
-                        }
+    $entwicklung_count = count($entwicklung);    
+    $installation_count = count($installation);
+    for( $i=0; $i<$entwicklung_count; $i++ ) {
+        if (remoteFileExists($firmware_download_path.$entwicklung[$i]."/")) {
+            for( $j=0; $j<$installation_count; $j++ ) {
+                //Check if URL has index file (refer to https://forums.phpfreaks.com/topic/112764-using-scandir-on-other-websites/?p=579166  <- scandir has problem with index files)
+                if ((@remoteFileExists($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/index.htm"))||(@remoteFileExists($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/index.html"))||(@remoteFileExists($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/index.php"))) {
+                    throw new Exception("Firmwareverzeichnis darf keine index files besitzen!");
+                }
+                $variante[$entwicklung[$i]][$installation[$j]] = 1;
+                preg_match_all('/href=[\'"]?([^\'" >]+)/', file_get_contents($firmware_download_path.$entwicklung[$i]."/".$installation[$j]."/"), $files_in_HTTP);
+                foreach($files_in_HTTP["0"] as $key=>$value){
+                    if (strpos($value, 'manifest') !== false) {
+                        unset($files_in_HTTP["0"][$key]);
                     }
                 }
+                foreach($files_in_HTTP["0"] as $key=>$value){
+                    $files_in_HTTP["0"][$key]=substr($value, 6);
+                }
+                $files[$entwicklung[$i]][$installation[$j]] = array_slice($files_in_HTTP["0"], 1);
             }
         }
     }
-    for( $i=0; $i<count($entwicklung); $i++ ) {
-        for( $j=0; $j<count($installation); $j++ ) {
+
+    for( $i=0; $i<$entwicklung_count; $i++ ) {
+        for( $j=0; $j<$installation_count; $j++ ) {
             if($variante[$entwicklung[$i]][$installation[$j]] == 1) {
                 $x = 0;
                 while($files[$entwicklung[$i]][$installation[$j]][$x] !== false) {
@@ -189,10 +184,12 @@ if (filter_var($community[$community_id]["download_path"], FILTER_VALIDATE_URL) 
         }
     }
     $router = array();
-    for( $i=0; $i<count($entwicklung); $i++ ) {
-        for( $j=0; $j<count($installation); $j++ ) {
+    for( $i=0; $i<$entwicklung_count; $i++ ) {
+        for( $j=0; $j<$installation_count; $j++ ) {
             if($variante[$entwicklung[$i]][$installation[$j]] == 1) {
-                for( $x=0; $x<count($files[$entwicklung[$i]][$installation[$j]]); $x++) {
+                $file_count = count($files[$entwicklung[$i]][$installation[$j]]);
+                for( $x=0; $x<$some_count; $x++) {
+                    $anzahl_hersteller = count($hersteller);
                     for( $y=0; $y<$anzahl_hersteller; $y++) {
                         if($pos = stripos($files[$entwicklung[$i]][$installation[$j]][$x], $hersteller[$y]['filename'], $pos_hersteller[$entwicklung[$i]][$installation[$j]]-1) !== false) {
                             $router_tmp[$x]['hersteller'] = $hersteller[$y]['name'];
@@ -217,7 +214,8 @@ if (filter_var($community[$community_id]["download_path"], FILTER_VALIDATE_URL) 
                         $err++;
                     } else {
                         $router_neu = 1;
-                        for( $z=0; $z<count($router); $z++) {
+                        $router_count = count($router);
+                        for( $z=0; $z<$router_count; $z++) {
                             if(isset($router[$z])) {
                                 if((strcasecmp($router[$z]->hersteller, $router_tmp[$x]['hersteller']) == 0) && (strcasecmp($router[$z]->modell, $router_tmp[$x]['modell']) == 0) && (strcasecmp($router[$z]->version, $router_tmp[$x]['version']) == 0)) {
                                     $entinst = $entwicklung[$i].$installation[$j];
@@ -247,8 +245,8 @@ if (filter_var($community[$community_id]["download_path"], FILTER_VALIDATE_URL) 
         }
     }
 }
-
-for( $i=0; $i<count($router); $i++ ) { // Routerbilder einbauen
+$router_count = count($router);
+for( $i=0; $i<$router_count; $i++ ) { // Routerbilder einbauen
     if(is_dir(strtolower("router_images/".$router[$i]->hersteller))) {
         if(is_file(strtolower("router_images/".$router[$i]->hersteller."/".$router[$i]->modell."-".$router[$i]->version.".jpg"))) {
             $router[$i]->imagefront = strtolower("router_images/".$router[$i]->hersteller."/".$router[$i]->modell."-".$router[$i]->version.".jpg");

--- a/ffrouter_parsen.function.php
+++ b/ffrouter_parsen.function.php
@@ -188,7 +188,7 @@ if (filter_var($community[$community_id]["download_path"], FILTER_VALIDATE_URL) 
         for( $j=0; $j<$installation_count; $j++ ) {
             if($variante[$entwicklung[$i]][$installation[$j]] == 1) {
                 $file_count = count($files[$entwicklung[$i]][$installation[$j]]);
-                for( $x=0; $x<$some_count; $x++) {
+                for( $x=0; $x<$file_count; $x++) {
                     $anzahl_hersteller = count($hersteller);
                     for( $y=0; $y<$anzahl_hersteller; $y++) {
                         if($pos = stripos($files[$entwicklung[$i]][$installation[$j]][$x], $hersteller[$y]['filename'], $pos_hersteller[$entwicklung[$i]][$installation[$j]]-1) !== false) {


### PR DESCRIPTION
Wie in https://forum.freifunk.net/t/freifunk-hennef-firmware-downloader/12966/20?u=mtrnord angemerkt ist mit diesem Code die Funktion gegeben, dass man anstatt die Images lokal zu haben diese auch per HTTP einbinden kann in $download_path  (wichtig hierbei ist das ein / am ende der URL ist).
Getestet habe ich es mit images bei Helgoland und FFNord

Zudem habe ich die count funktion aus den for loops genommen, damit diese nicht jedesmal wenn eine "Runde" durchläuft neu gezählt wird. (Siehe:  http://stackoverflow.com/a/13466794/4929236  )
